### PR TITLE
Update outdated dependencies that no longer worked.

### DIFF
--- a/client-provider-txt/pom.xml
+++ b/client-provider-txt/pom.xml
@@ -21,15 +21,12 @@
 	</properties>
 
 	<dependencies>
-		<!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>${commons.io.version}</version>
 		</dependency>
 
-
-		<!-- https://mvnrepository.com/artifact/commons-codec/commons-codec -->
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
@@ -37,7 +34,6 @@
 		</dependency>
 
 		<!--This dependency is necessary to write tests using junit5 -->
-		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
@@ -45,17 +41,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!--This dependency is necessary to run junit5 on IDE. In this case on 
-			the Eclipse -->
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-runner</artifactId>
-			<version>${junit.platform.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-
-		<!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
@@ -63,7 +48,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
@@ -88,16 +72,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19</version>
-				<dependencies>
-					<!--This dependency is necessary to run junit5 with maven. The tests 
-						will be run when the project is built by maven. -->
-					<dependency>
-						<groupId>org.junit.platform</groupId>
-						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>${junit.platform.version}</version>
-					</dependency>
-				</dependencies>
+				<version>${maven-surefire-plugin.version}</version>
 			</plugin>
 
 			<plugin>

--- a/competitive-location/pom.xml
+++ b/competitive-location/pom.xml
@@ -25,15 +25,6 @@
 			<scope>test</scope>
 		</dependency>
 
-	    <!--This dependency is necessary to run junit5 on IDE. In this case on the Eclipse  -->
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-runner</artifactId>
-			<version>${junit.platform.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-
 		<!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
 		<dependency>
 			<groupId>org.assertj</groupId>
@@ -68,15 +59,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19</version>
-				<dependencies>
-					<!--This dependency is necessary to run junit5 with maven. The tests will be run when the project is built by maven.  -->
-					<dependency>
-						<groupId>org.junit.platform</groupId>
-						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>${junit.platform.version}</version>
-					</dependency>
-				</dependencies>
+				<version>${maven-surefire-plugin.version}</version>
 			</plugin>
 			
 			<plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,6 @@
 		<java.version>1.8</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<junit.platform.version>1.1.0</junit.platform.version>
 		<mockito.version>1.10.19</mockito.version>
 		<location.query.version>0.0.1-SNAPSHOT</location.query.version>
 		<snakeyaml.version>1.18</snakeyaml.version>
@@ -29,31 +28,18 @@
 	
 	<dependencies>
 		<!--This dependency is necessary to write tests using junit5 -->
-		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 
-		<!--This dependency is necessary to run junit5 on IDE. In this case on 
-			the Eclipse -->
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-runner</artifactId>
-			<version>${junit.platform.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-
-		<!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
@@ -88,7 +74,7 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
-			<!-- Exclude JUnit 4 from starter-test (and all other related test-starter, i.e
+			<!-- Exclude JUnit 4 from starter-test (and all other related test-starter, i.e.
 			     those for security and project reactor -->
 			<exclusions>
 				<exclusion>
@@ -96,21 +82,6 @@
 					<artifactId>junit</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
-		<!--This dependency is necessary to write tests using junit5 -->
-		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-	    <!--This dependency is necessary to run junit5 on IDE. In this case on the Eclipse  -->
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-runner</artifactId>
-			<version>${junit.platform.version}</version>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
@@ -124,16 +95,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19</version><!--$NO-MVN-MAN-VER$-->
-				<dependencies>
-					<!--This dependency is necessary to run junit5 with maven. The tests 
-						will be run when the project is built by maven. -->
-					<dependency>
-						<groupId>org.junit.platform</groupId>
-						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>${junit.platform.version}</version>
-					</dependency>
-				</dependencies>
+				<version>${maven-surefire-plugin.version}</version><!--$NO-MVN-MAN-VER$-->
 			</plugin>
 		</plugins>
 	</build>

--- a/location-query/pom.xml
+++ b/location-query/pom.xml
@@ -11,8 +11,8 @@
 	<properties>
 		<junit.jupiter.version>5.1.0</junit.jupiter.version>
 		<assertj.version>3.9.1</assertj.version>
-		<junit.platform.version>1.1.0</junit.platform.version>
 		<mockito.version>1.10.19</mockito.version>
+        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
 	</properties>
 	
 	<parent>
@@ -24,7 +24,6 @@
 
 	<dependencies>
 		<!--This dependency is necessary to write tests using junit5 -->
-		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
@@ -32,16 +31,6 @@
 			<scope>test</scope>
 		</dependency>
 
-	<!--This dependency is necessary to run junit5 on IDE. In this case on the Eclipse  -->
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-runner</artifactId>
-			<version>${junit.platform.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-
-		<!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
@@ -49,7 +38,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
@@ -69,15 +57,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19</version>
-				<dependencies>
-					<!--This dependency is necessary to run junit5 with maven. The tests will be run when the project is built by maven.  -->
-					<dependency>
-						<groupId>org.junit.platform</groupId>
-						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>${junit.platform.version}</version>
-					</dependency>
-				</dependencies>
+				<version>${maven-surefire-plugin.version}</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/locationQuery-cmd/settings.yaml
+++ b/locationQuery-cmd/settings.yaml
@@ -5,7 +5,7 @@
 #The jar must be placed in the LocationQueries folder.
 locationQuery: min-clients-0.0.1-SNAPSHOT
 #The jar must be placed in the ClientProviders folder.
-clientProvider: client-provider-txt
+clientProvider: client-provider-fake-0.0.1-SNAPSHOT
 #The jar must be placed in the FacilityProviders folder.
 facilityProvider: facility-provider-fake-0.0.1-SNAPSHOT
 #The jar must be placed in the CandidateProviders folder.

--- a/locationQuery-rest/pom.xml
+++ b/locationQuery-rest/pom.xml
@@ -13,7 +13,6 @@
 		<java.version>1.8</java.version>
 		<optimalLocation.core.version>0.0.1-SNAPSHOT</optimalLocation.core.version>
 		<snakeyaml.version>1.18</snakeyaml.version>
-		<junit.platform.version>1.1.0</junit.platform.version>
 	</properties>
 
 	<parent>
@@ -60,29 +59,13 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-	    <!--This dependency is necessary to run junit5 on IDE. In this case on the Eclipse  -->
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-runner</artifactId>
-			<version>${junit.platform.version}</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19</version><!--$NO-MVN-MAN-VER$-->
-				<dependencies>
-					<!--This dependency is necessary to run junit5 with maven. The tests will be run when the project is built by maven.  -->
-					<dependency>
-						<groupId>org.junit.platform</groupId>
-						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>${junit.platform.version}</version>
-					</dependency>
-				</dependencies>
+				<version>${maven-surefire-plugin.version}</version><!--$NO-MVN-MAN-VER$-->
 			</plugin>
 			
 			<plugin>

--- a/locationQuery-rest/settings.yaml
+++ b/locationQuery-rest/settings.yaml
@@ -5,7 +5,7 @@
 #The jar must be placed in the LocationQueries folder.
 locationQuery: min-clients-0.0.1-SNAPSHOT
 #The jar must be placed in the ClientProviders folder.
-clientProvider: client-provider-txt
+clientProvider: client-provider-fake-0.0.1-SNAPSHOT
 #The jar must be placed in the FacilityProviders folder.
 facilityProvider: facility-provider-fake-0.0.1-SNAPSHOT
 #The jar must be placed in the CandidateProviders folder.

--- a/min-clients/pom.xml
+++ b/min-clients/pom.xml
@@ -16,8 +16,6 @@
 	</parent>
 
 	<dependencies>
-		<!--This dependency is necessary to write tests using junit5 -->
-		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
@@ -25,16 +23,6 @@
 			<scope>test</scope>
 		</dependency>
 
-	    <!--This dependency is necessary to run junit5 on IDE. In this case on the Eclipse  -->
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-runner</artifactId>
-			<version>${junit.platform.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-
-		<!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
@@ -42,7 +30,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
@@ -68,15 +55,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19</version>
-				<dependencies>
-					<!--This dependency is necessary to run junit5 with maven. The tests will be run when the project is built by maven.  -->
-					<dependency>
-						<groupId>org.junit.platform</groupId>
-						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>${junit.platform.version}</version>
-					</dependency>
-				</dependencies>
+				<version>${maven-surefire-plugin.version}</version>
 			</plugin>
 			
 			<plugin>

--- a/min-clients/src/test/java/fagner/min_clients/AppTest.java
+++ b/min-clients/src/test/java/fagner/min_clients/AppTest.java
@@ -1,6 +1,6 @@
 package fagner.min_clients;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import optimalLocation.min_clients.App;
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -16,10 +16,10 @@
 	<maven.compiler.source>${java.version}</maven.compiler.source>
 	<maven.compiler.target>${java.version}</maven.compiler.target>
 	<location.query.version>0.0.1-SNAPSHOT</location.query.version>
-	<junit.jupiter.version>5.1.0</junit.jupiter.version>
+	<junit.jupiter.version>5.11.0</junit.jupiter.version>
 	<assertj.version>3.9.1</assertj.version>
-	<junit.platform.version>1.1.0</junit.platform.version>
 	<mockito.version>1.10.19</mockito.version>
+    <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
1. Remove junit-platform-runner dependency. This was used in the past to integrate Junit Jupiter when it was not fully integrated with maven. This is no longer necessary, and the dependency is no longer available in maven public repositories.
2. Update maven-surefire-plugin version from 2.19 to 3.5.3. The updated version has Junit Jupiter runner embedded and the configuration is simpler.
3. Remove additional Junit Jupiter configuration as everything is now embeeded with maven-surefure-plugin.
4. Update junit-jupiter-engine version from 5.1.0 to 5.110 because the older version was not compatible with the new maven-surefire-plugin-version.
5. Update settings.yaml to point to the correct Client provider that is currently generated by the parent module.

Prior to this changes the java modules were not building or running. Now the the modules are built successfully with jdk 8, and we can run both cmd and rest application.